### PR TITLE
Fix versionless install/uninstall scripts to include full winget args

### DIFF
--- a/src/WingetIntune/Intune/IntuneManager.cs
+++ b/src/WingetIntune/Intune/IntuneManager.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Text.Json;
 using WingetIntune.Commands;
 using WingetIntune.Graph;
+using WingetIntune.Implementations;
 using WingetIntune.Interfaces;
 using WingetIntune.Internal.Msal;
 using WingetIntune.Msi;
@@ -132,7 +133,17 @@ public partial class IntuneManager
 
         if (packageOptions.Versionless)
         {
-            var installScript = IntuneManagerConstants.GetWingetInstallCmd(packageInfo.PackageIdentifier!);
+            var installArgs = WingetHelper.GetInstallArgumentsForPackage(
+                packageInfo.PackageIdentifier!,
+                version: null,
+                source: "winget",
+                installerContext: packageInfo.InstallerContext ?? InstallerContext.Unknown);
+            var installScript = GetPsCommandContent(
+                "winget " + installArgs,
+                successSearch: "installed",
+                message: $"Package {packageInfo.PackageIdentifier} installed successfully",
+                packageId: packageInfo.PackageIdentifier,
+                action: "install");
             await fileManager.WriteAllTextAsync(
                 Path.Combine(packageTempFolder, "install.ps1"),
                 installScript,
@@ -144,7 +155,16 @@ public partial class IntuneManager
             packageInfo.InstallCommandLine = $"%windir%\\sysnative\\windowspowershell\\v1.0\\powershell.exe -WindowStyle Hidden -ExecutionPolicy Bypass -File install.ps1";
             packageInfo.InstallerFilename = "install.ps1";
 
-            var uninstallScript = IntuneManagerConstants.GetWingetUninstallCmd(packageInfo.PackageIdentifier!);
+            var uninstallArgs = WingetHelper.GetUninstallArgumentsForPackage(
+                packageInfo.PackageIdentifier!,
+                source: "winget",
+                installerContext: packageInfo.InstallerContext ?? InstallerContext.Unknown);
+            var uninstallScript = GetPsCommandContent(
+                "winget " + uninstallArgs,
+                successSearch: "uninstalled",
+                message: $"Package {packageInfo.PackageIdentifier} uninstalled successfully",
+                packageId: packageInfo.PackageIdentifier,
+                action: "uninstall");
             await fileManager.WriteAllTextAsync(
                 Path.Combine(packageTempFolder, "uninstall.ps1"),
                 uninstallScript,

--- a/src/WingetIntune/Intune/IntuneManagerConstants.cs
+++ b/src/WingetIntune/Intune/IntuneManagerConstants.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Graph.Beta.Models.TermStore;
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace WingetIntune.Intune;
 
@@ -26,22 +25,6 @@ internal class IntuneManagerConstants
             .Replace("{packageId}", packageId ?? Guid.NewGuid().ToString());
 
         return script;
-    }
-
-    internal static string GetWingetInstallCmd(string packageId, string? version = null)
-    {
-        var command = version is null
-            ? $"$(Get-WingetCmd) \"install\" \"--id\" \"{packageId}\" \"--exact\""
-            : $"$(Get-WingetCmd) \"install\" \"--id\" \"{packageId}\" \"--exact\" \"--version\" \"{version}\"";
-        return GetPsWingetCmd("install", command, "installed", $"Package {packageId} v{version} installed successfully", packageId);
-    }
-
-    internal static string GetWingetUninstallCmd(string packageId, string? version = null)
-    {
-        var command = version is null
-            ? $"$(Get-WingetCmd) \"uninstall\" \"--id\" \"{packageId}\" \"--exact\""
-            : $"$(Get-WingetCmd) \"uninstall\" \"--id\" \"{packageId}\" \"--exact\" \"--version\" \"{version}\"";
-        return GetPsWingetCmd("uninstall", command, "uninstalled", $"Package {packageId} v{version} uninstalled successfully", packageId);
     }
 
     internal static string GetPsGetWingetCmd()

--- a/tests/WingetIntune.Tests/Intune/IntuneManagerTests.cs
+++ b/tests/WingetIntune.Tests/Intune/IntuneManagerTests.cs
@@ -113,6 +113,97 @@ The Azure command-line interface (Azure CLI) is a set of commands used to create
 
     }
 
+    [Theory]
+    [InlineData(InstallerContext.User, true, "--scope", "user")]
+    [InlineData(InstallerContext.System, true, "--scope", "machine")]
+    [InlineData(InstallerContext.Unknown, false, "--scope", null)]
+    public async Task GenerateInstallerPackage_Versionless_ScriptsContainFullWingetArgs(InstallerContext installerContext, bool expectScope, string scopeArg, string? scopeValue)
+    {
+        var packageId = "Test.Package";
+        var version = "1.0.0";
+        var tempFolder = Path.Combine(Path.GetTempPath(), "intunewin-versionless");
+        var outputFolder = Path.Combine(Path.GetTempPath(), "packages-versionless");
+        var tempPackageFolder = Path.Combine(tempFolder, packageId, version);
+        var outputPackageFolder = Path.Combine(outputFolder, packageId, "latest");
+
+        var packageInfo = new PackageInfo
+        {
+            PackageIdentifier = packageId,
+            DisplayName = "Test Package",
+            Version = version,
+            Source = PackageSource.Winget,
+            InstallerContext = installerContext,
+            InstallerType = InstallerType.Exe,
+            InstallCommandLine = $"winget install --id {packageId} --version {version} --source winget --silent --accept-package-agreements --accept-source-agreements",
+            UninstallCommandLine = $"winget uninstall --id {packageId} --source winget --silent --accept-source-agreements",
+            InstallerFilename = "setup.exe",
+            Installers =
+            [
+                new WingetInstaller
+                {
+                    Architecture = "x64",
+                    Scope = installerContext == InstallerContext.User ? "user"
+                          : installerContext == InstallerContext.System ? "machine"
+                          : null,
+                    InstallerType = "exe",
+                    InstallerUrl = "https://localhost/setup.exe",
+                }
+            ],
+        };
+
+        var capturedScripts = new Dictionary<string, string>();
+
+        var fileManager = Substitute.For<IFileManager>();
+        fileManager.CreateFolderForPackage(tempFolder, packageId, version, false).Returns(tempPackageFolder);
+        fileManager.CreateFolderForPackage(outputFolder, packageId, "latest", false).Returns(outputPackageFolder);
+        fileManager.WriteAllTextAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                capturedScripts[Path.GetFileName(ci.ArgAt<string>(0))] = ci.ArgAt<string>(1);
+                return Task.CompletedTask;
+            });
+        fileManager.WriteAllBytesAsync(Arg.Any<string>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+        fileManager.DownloadFileAsync(Arg.Any<string>(), Arg.Any<string>(), null, false, false, Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+
+        var intunePackager = Substitute.For<IIntunePackager>();
+        intunePackager.CreatePackage(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<PackageInfo>(), Arg.Any<bool>(), cancellationToken: Arg.Any<CancellationToken>())
+            .Returns("test.intunewin");
+
+        var intuneManager = new IntuneManager(new NullLoggerFactory(), fileManager, null, null, null, null, intunePackager, null, null, null, new ComputeBestInstallerForPackageCommand());
+
+        await intuneManager.GenerateInstallerPackage(tempFolder, outputFolder, packageInfo, new PackageOptions { Versionless = true, PackageScript = true, InstallerContext = installerContext }, CancellationToken.None);
+
+        Assert.True(capturedScripts.ContainsKey("install.ps1"), "install.ps1 was not written");
+        Assert.True(capturedScripts.ContainsKey("uninstall.ps1"), "uninstall.ps1 was not written");
+
+        var installScript = capturedScripts["install.ps1"];
+        Assert.Contains("--source", installScript);
+        Assert.Contains("winget", installScript);
+        Assert.Contains("--silent", installScript);
+        Assert.Contains("--accept-package-agreements", installScript);
+        Assert.Contains("--accept-source-agreements", installScript);
+        Assert.DoesNotContain("--version", installScript);
+
+        var uninstallScript = capturedScripts["uninstall.ps1"];
+        Assert.Contains("--source", uninstallScript);
+        Assert.Contains("--silent", uninstallScript);
+        Assert.Contains("--accept-source-agreements", uninstallScript);
+        Assert.DoesNotContain("--version", uninstallScript);
+
+        if (expectScope)
+        {
+            Assert.Contains(scopeArg, installScript);
+            Assert.Contains(scopeValue!, installScript);
+            Assert.Contains(scopeArg, uninstallScript);
+            Assert.Contains(scopeValue!, uninstallScript);
+        }
+        else
+        {
+            Assert.DoesNotContain(scopeArg, installScript);
+            Assert.DoesNotContain(scopeArg, uninstallScript);
+        }
+    }
+
     [Fact]
     public async Task DownloadInstallerAsync_CallsFilemanager()
     {


### PR DESCRIPTION
Fixes #240

When running `New-WtWingetPackage -version latest -PackageScript`, the generated scripts were missing most of the winget arguments:

```powershell
# what you got
$(Get-WingetCmd) "install" "--id" "Microsoft.VisualStudioCode" "--exact"

# what you'd get with an explicit version
$(Get-WingetCmd) "install" "--id" "Microsoft.VisualStudioCode" "--version" "1.104.2" "--source" "winget" "--silent" "--accept-package-agreements" "--accept-source-agreements" "--scope" "user"
```

The versionless path had its own hardcoded command builders that never got the `--source`, `--silent`, `--accept-*` and `--scope` treatment. The non-versionless path was already using `WingetHelper.GetInstallArgumentsForPackage` which does all of that correctly so the fix is just making both paths use the same thing.

Removed `GetWingetInstallCmd` and `GetWingetUninstallCmd` from `IntuneManagerConstants` since nothing else used them.

Added tests for `InstallerContext.User`, `System` and `Unknown` to make sure the right flags (including `--scope`) end up in the generated scripts.