### PR TITLE
Fix detection script to handle spinner lines and trailing count summaries in winget output

### DIFF
--- a/src/WingetIntune/Scripts/WingetDetection.ps1
+++ b/src/WingetIntune/Scripts/WingetDetection.ps1
@@ -46,11 +46,25 @@ Function Get-ColumnValuesFromWingetOutput {
     }
 
     if ($Output -is [array] -and $Output.Length -gt 2) {
-        # $Output is an array, first row is header, last row is data
-        # this will break if multiple lines are returned, but that should not happen with --exact
-        #$headerRow = $Output[$Output.Length - 3]
-        $headerRow = $Output | Where-Object { $_ -match '^[A-Za-z]' } | Select-Object -First 1
-        $lastRow = $Output[$Output.Length - 1]
+        # Anchor on the separator line (--- dashes) which is stable across winget versions.
+        # Newer winget appends a "N package(s)" count line, so we cannot rely on $Output[-1].
+        # Source-refresh messages ("Updating sources...") appear before the table, so we
+        # cannot rely on the first alpha line being the header.
+        $separatorIndex = -1
+        for ($s = 0; $s -lt $Output.Length; $s++) {
+            if ($Output[$s] -match '^-{10,}') {
+                $separatorIndex = $s
+                break
+            }
+        }
+
+        if ($separatorIndex -le 0 -or $separatorIndex + 1 -ge $Output.Length) {
+            Write-Host "Could not find separator line in winget output"
+            return @()
+        }
+
+        $headerRow = $Output[$separatorIndex - 1]
+        $lastRow = $Output[$separatorIndex + 1]
 
         # Find the start index of each column by searching for non-space transitions
         $columnStarts = @()
@@ -63,12 +77,16 @@ Function Get-ColumnValuesFromWingetOutput {
         # Add the end of the line as the last column boundary
         $columnStarts += $lastRow.Length
 
-        # Extract column values from the data row
+        # Extract column values from the data row, guarding against short rows
         $columns = @()
         for ($i = 0; $i -lt $columnStarts.Count - 1; $i++) {
             $start = $columnStarts[$i]
-            $length = $columnStarts[$i + 1] - $start
-            $columns += $lastRow.Substring($start, $length).Trim()
+            if ($start -ge $lastRow.Length) {
+                $columns += ""
+            } else {
+                $length = [Math]::Min($columnStarts[$i + 1] - $start, $lastRow.Length - $start)
+                $columns += $lastRow.Substring($start, $length).Trim()
+            }
         }
 
         return $columns


### PR DESCRIPTION
Fixes the auto-generated detection scripts that use `winget list` to check
whether an app installed by Intune is present. Apps were consistently
reported as not installed even when they were.

Recent winget versions (1.7+) write progress spinner lines to stdout before
the package table, and some versions append a `N package(s)` count line
after it. The parser assumed the first alpha line was the header and the
last line was the data row. Both assumptions break with the new output
format:

```
""
"   - "           ← spinner lines captured in stdout
"   \ "
"Name   Id   Version   Source"
"-----------------------------"
"7-Zip  7zip.7zip  26.00  winget"
"1 package(s)"    ← trailing count line in some versions
```

The header and data row are now anchored on the separator line (`^-{10,}`)
which is stable across all winget versions and unaffected by anything
prepended or appended around the table.

Also fixed a latent `ArgumentOutOfRangeException` in `Substring()` that
would crash the script when a data row is shorter than the last header
column position (e.g. when the Available and Source fields are blank and
winget trims trailing whitespace).